### PR TITLE
[desktop] let game board be visible when modals are open

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -623,3 +623,48 @@ MEDIA QUERIES
     font-size: 2em;
   }
 }
+
+.appContainer, .Toastify__toast-container--top-center {
+    transition: transform 0.2s ease-in-out;
+}
+
+@keyframes fade-in {
+    from {
+        opacity: 0;
+    }
+    to {
+	opacity: 1;
+    }
+}
+
+@media (min-width: 1100px) {
+
+    .ReactModal__Overlay.ReactModal__Overlay--after-open {
+	display: contents;  /* allow interaction with main board */
+    }
+
+    .ReactModal__Content.ReactModal__Content--after-open {
+	/* important to overcome inline style */
+	transform: translate(0, -50%) !important;
+	position: fixed !important;  /* do what the overlay was doing */
+	animation: fade-in 0.5s normal forwards ease-in-out;
+    }
+
+    .ReactModal__Body--open .appContainer {
+	transform: translateX(-50%);
+	position: relative;
+	z-index: 1;  /* for Toastify to appear above */
+    }
+
+    .ReactModal__Body--open .Toastify__toast-container--top-center {
+	transform: translateX(calc(-50% + 250px)) !important;  /* center across both sides */
+    }
+
+    .ReactModal__Body--open .appContainer .appHeader button {
+	visibility: hidden;  /* a quick hack rather than try to work out how to switch between modals */
+    }
+
+    .infoModal-Container .endGameButton {
+	display: none;  /* not needed as the board is visible on left at this screen width */
+    }
+}


### PR DESCRIPTION
 - the main motivator was that I like being able to keep looking at the final successful board after the game ended (when that statistics modal opens)
 - this is a hacky enough solution in that I haven't attempted to modify any of the js/typescript side of things